### PR TITLE
Adding get_structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,19 @@ Optional arguments:
 
 ### Credits
 This tool is based on other scientific research. And is only usefull with [pcfg_cracker](https://github.com/lakiw/pcfg_cracker) created by Matt Weir.
+
+## get_structures.py
+A tool that can be used to build wordlists from pre-trainer rule sets. Simply specify the rule set and tell the script what you need. The script will simply go in to the `Alpha` folder (when `alpha` is enable), loop over the files in there, and only get the alphas without the probability.
+
+### Requirements
+🐍 Python 3.x
+
+### Usage
+Run the script from the command line with the necessary arguments. Here is the basic syntax:
+```
+python keepyour.py --rule [RULE] [--alpha] --min_length [MIN_LENGTH] --max_length [MAX_LENGTH]
+```
+ * `RULE`: Name of the rule.
+ * `alpha`: set to true if you want to only get the alpha strings
+ * `MIN_LENGTH`: minimal length of the structure go get from the rule
+ * `MAX_LENGTH`: maximal length of the structure go get from the rule

--- a/get_structures.py
+++ b/get_structures.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+########################################################################################
+#
+# Name: get_structures
+#  --Want to get words from a rule set? Then this is the tool for you!
+#  --Easy wordlist builder from Rule set
+#
+#  get_structures.py
+#
+#########################################################################################
+
+import argparse
+import os
+import sys
+
+def parse_command_line(program_info):
+    # Keeping the title text to be generic to make re-using code easier
+    parser = argparse.ArgumentParser(
+        description= program_info['name'] +
+        ', version: ' + 
+        program_info['version']
+    )
+
+    parser.add_argument(
+        '--rule',
+        '-r',
+        help = 'Input rule, from which to get.',
+        required = True,
+    )
+    parser.add_argument(
+        '--alpha',
+        '-a',
+        help = 'Only get the Alphas, like words.',
+        action = 'store_true',
+        required = False,
+        default = False
+    )
+    
+    parser.add_argument(
+        '--min_length',
+        help = 'If used, checks for the minimal length of grammars.',
+        type=int,
+        default = 0,
+    )
+
+    parser.add_argument(
+        '--max_length',
+        help = 'If used, checks for the minimal length of grammars.',
+        type=int,
+        default = 40,
+    )
+    parser.add_argument(
+        '--rules_dir',
+        '-D',
+        help = 'Path to the Rules folder',
+        required = False,
+        action='store',
+        default = os.path.join('..', 'pcfg_cracker', 'Rules')
+    )
+
+    args=parser.parse_args()
+    program_info['alpha'] = args.alpha
+    program_info['rule'] = args.rule
+    program_info['rules_dir'] = args.rules_dir
+    program_info['max_length'] = args.max_length
+    program_info['min_length'] = args.min_length
+    
+    return True
+
+def main():
+    program_info = {
+        # Program and Contact Info
+        'name': 'PCFG Get Structures',
+        'version': '1.0',
+    }
+    print('PCFG Get Structures', file=sys.stderr)
+    print("Version: " + str(program_info['version']), file=sys.stderr)
+
+    # Parsing the command line
+    if not parse_command_line(program_info):
+        # There was a problem with the command line so exit
+        print("Exiting...")
+        return
+
+    if program_info['alpha']:
+        for n in range(program_info['min_length'], program_info['max_length'] + 1):
+            n = f"{n}.txt"
+            path = os.path.join(program_info['rules_dir'], program_info['rule'], 'Alpha', n)
+            if os.path.isfile(path):
+                with open(os.path.join(program_info['rules_dir'], program_info['rule'], 'Alpha', n)) as f:
+                    for line in f.readlines():
+                        line = line.rstrip('\n')
+                        line = line.split('\t')[0]
+                        print(line)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
This pull request adds documentation and example usage for the get_structures.py script in the pcfg_cracker repository.

The get_structures.py script is a tool for extracting words from a rule set, making it easier to build wordlists from those rules. It provides an option to filter and retrieve only alphabetic characters (words) from the rules.

## Usage
```
python3 get_structures.py --rule RULE_NAME --alpha
```

## Example:
```
ubuntu@8MQD6R3:~/workspace/pcfg_tools$ python3 get_structures.py -r Default --alpha --max_length 5 --min_length 3 | head
PCFG Get Structures
Version: 1.0
abc
eva
may
you
red
luv
jan
sam
feb
dec
```